### PR TITLE
Fix namespace key spelling

### DIFF
--- a/app/ine.ipynb
+++ b/app/ine.ipynb
@@ -3843,7 +3843,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "namespace = \"Ministra_o_Suprema_Corte_de_Justicia_de_la_Nacin_texts\"  # Use your sanitized namespace\n",
+    "namespace = \"Ministra_o_Suprema_Corte_de_Justicia_de_la_Nación_texts\"  # Use your sanitized namespace\n",
     "\n",
     "query = \"Por que ministro o ministra me conviene votar si mi prioridad es la anti corrupcion?\"\n",
     "\n",

--- a/app/src/namespace.py
+++ b/app/src/namespace.py
@@ -2,7 +2,7 @@ NAMESPACE_MAP = {
     "Magistraturas de Tribunales Colegiados de Circuito": "Magistraturas_de_Tribunales_Colegiados_de_Circuito_texts",
     "Juezas/es de Distrito": "Juezas_es_de_Distrito_texts",
     "Magistratura Salas Regionales del TE del PJF": "Magistratura_Salas_Regionales_del_TE_del_PJF_texts",
-    "Ministra/o Suprema Corte de Justicia de la Nación": "Ministra_o_Suprema_Corte_de_Justicia_de_la_Nacin_texts",
+    "Ministra/o Suprema Corte de Justicia de la Nación": "Ministra_o_Suprema_Corte_de_Justicia_de_la_Nación_texts",
     "Magistratura Tribunal de Disciplina Judicial": "Magistratura_Tribunal_de_Disciplina_Judicial_texts",
     "Magistratura Sala Superior del TE del PJF": "Magistratura_Sala_Superior_del_TE_del_PJF_texts"
 }

--- a/app/src/utils/config.py
+++ b/app/src/utils/config.py
@@ -10,7 +10,7 @@ NAMESPACE_OPTIONS = [
     "Magistraturas_de_Tribunales_Colegiados_de_Circuito_texts",
     "Juezas_es_de_Distrito_texts",
     "Magistratura_Salas_Regionales_del_TE_del_PJF_texts",
-    "Ministra_o_Suprema_Corte_de_Justicia_de_la_Nacin_texts",
+    "Ministra_o_Suprema_Corte_de_Justicia_de_la_Nación_texts",
     "Magistratura_Tribunal_de_Disciplina_Judicial_texts",
     "Magistratura_Sala_Superior_del_TE_del_PJF_texts"
 ]


### PR DESCRIPTION
## Summary
- use `Ministra_o_Suprema_Corte_de_Justicia_de_la_Nación_texts` namespace
- fix config list to use the same key
- update notebook example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a633ff450832a9503bce6418b06ab